### PR TITLE
Redactor's options can be configured globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ With Options
 
 You can pass options directly to Redactor by specifying them as the value of the `redactor` attribute.
 
+Global Options
+```js
+angular.module('app', ['angular-redactor'])
+  .config(function(redactorOptions) {
+    redactorOptions.buttons = ['formatting', '|', 'bold', 'italic']; 
+  });
+```
+
 
 Check out the demo folder where you can see a working example.  https://github.com/TylerGarlick/angular-redactor/tree/master/demo
 

--- a/angular-redactor.js
+++ b/angular-redactor.js
@@ -8,11 +8,15 @@
    *      redactor: hash (pass in a redactor options hash)
    *
    */
+
+  var redactorOptions = {};
+
   angular.module('angular-redactor', [])
-    .directive("redactor", ['$timeout', function ($timeout) {
+    .constant('redactorOptions', redactorOptions)
+    .directive('redactor', ['$timeout', function ($timeout) {
       return {
         restrict: 'A',
-        require: "ngModel",
+        require: 'ngModel',
         link: function (scope, element, attrs, ngModel) {
 
           var updateModel = function updateModel(value) {
@@ -24,11 +28,11 @@
               changeCallback: updateModel
             },
             additionalOptions = attrs.redactor ?
-                                scope.$eval(attrs.redactor) : {},
+              scope.$eval(attrs.redactor) : {},
             editor,
             $_element = angular.element(element);
 
-          angular.extend(options, additionalOptions);
+          angular.extend(options, redactorOptions, additionalOptions);
 
           // put in timeout to avoid $digest collision.  call render() to
           // set the initial value.


### PR DESCRIPTION
This allows redactor's options to be defined during the app config stage.
