### PR TITLE
Use `code.set` rather than `insert.set`.

### DIFF
--- a/angular-redactor.js
+++ b/angular-redactor.js
@@ -59,7 +59,7 @@
                     ngModel.$render = function() {
                         if(angular.isDefined(editor)) {
                             $timeout(function() {
-                                $_element.redactor('insert.set', ngModel.$viewValue || '');
+                                $_element.redactor('code.set', ngModel.$viewValue || '');
                                 scope.redactorLoaded = true;
                             });
                         }


### PR DESCRIPTION
Hello Tyler,

This change addresses some issues we're seeing where Redactor treats the incoming html as user input from a human, rather than code input from the backend.
- http://imperavi.com/redactor/docs/api/code/#api-set
- http://imperavi.com/redactor/docs/api/insert/#api-set

In our case, `insert.set` collapses a sequence of `<p><br></p>` tags even if the user entered and desires them, while `code.set` leaves them intact.

Would this change make sense for the larger community as well?

Thanks!
- Brandon
