### PR TITLE
redactor not being destroyed properly

### DIFF
--- a/angular-redactor.js
+++ b/angular-redactor.js
@@ -54,6 +54,10 @@
                     $timeout(function() {
                         editor = $_element.redactor(options);
                         ngModel.$render();
+                        element.on('remove',function(){
+                            element.off('remove');
+                            element.redactor('core.destroy');
+                        });
                     });
 
                     ngModel.$render = function() {


### PR DESCRIPTION
$timeout(function() {
                        editor = $_element.redactor(options);
                        ngModel.$render();
                        element.on('remove',function(){
                            element.off('remove');
                            element.redactor('core.destroy');
                        });
                    });