### PR TITLE
Define callbacks on initialisation

### DIFF
--- a/angular-redactor.js
+++ b/angular-redactor.js
@@ -37,7 +37,14 @@
                             scope.$eval(attrs.redactor) : {},
                         editor;
 
-                    angular.extend(options, redactorOptions, additionalOptions);
+                    var redactorCallbacks = {};
+                    if (additionalOptions.hasOwnProperty('callbacks') === true){
+                        additionalOptions.callbacks.forEach(function(callback){
+                            redactorCallbacks[callback] = window[callback]
+                        });
+                    }
+
+                    angular.extend(options, redactorOptions, additionalOptions, redactorCallbacks);
 
                     // prevent collision with the constant values on ChangeCallback
                     var changeCallback = additionalOptions.changeCallback || redactorOptions.changeCallback;
@@ -72,4 +79,3 @@
             };
         }]);
 })();
-


### PR DESCRIPTION
I wanted to initialise redactor with callbacks, as well as options, passed into the `redactor` attribute.

You can't simply throw function definitions in there, so I attached them to `window`, and reference them according to name.

Not sure if this is the best approach, any thoughts?